### PR TITLE
[ABT-01M] Inexistent Initialization Protection of Base Implementation

### DIFF
--- a/abis/AllianceBlockToken.json
+++ b/abis/AllianceBlockToken.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/contracts/AllianceBlockToken.sol
+++ b/contracts/AllianceBlockToken.sol
@@ -13,6 +13,10 @@ contract AllianceBlockToken is ERC20PresetMinterPauserUpgradeable, ERC20Snapshot
 
     event BatchMint(address indexed sender, uint256 recipientsLength, uint256 totalValue);
 
+    constructor() {
+        init("AllianceBlockToken Implementation", "IMPL", address(this), address(this), 1);
+    }
+
     function init(string memory name, string memory symbol, address admin, address minter, uint256 cap_) public initializer {
         __ERC20_init_unchained(name, symbol);
         __ERC20Snapshot_init_unchained();

--- a/contracts/test/TestProxy.sol
+++ b/contracts/test/TestProxy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract TestProxy is TransparentUpgradeableProxy {
+    /**
+     * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
+     * optionally initialized with `_data` as explained in {ERC1967Proxy-constructor}.
+     */
+    constructor(
+        address _logic,
+        address admin_,
+        bytes memory _data
+    ) payable TransparentUpgradeableProxy(_logic, admin_, _data) {}
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@openzeppelin/contracts": "^4.8.1",
     "@openzeppelin/contracts-upgradeable": "^4.8.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,6 +726,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz#363f7dd08f25f8f77e16d374350c3d6b43340a7a"
   integrity sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw==
 
+"@openzeppelin/contracts@^4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.1.tgz#709cfc4bbb3ca9f4460d60101f15dac6b7a2d5e4"
+  integrity sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ==
+
 "@scure/base@~1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"


### PR DESCRIPTION
We advise a constructor to be introduced that invokes the initializer modifier of the Initializable contract to prevent the base implementation from ever being initialized.
Created TestProxy to test ERC20 without a fixture
Imported @openzeppelin/contracts as @openzeppelin/contracts-upgreadables does not have transparent proxy 

Close #11