### PR TITLE
[ABT-02S] Inexistent Sanitization of Input Addresses

### DIFF
--- a/abis/AllianceBlockToken.json
+++ b/abis/AllianceBlockToken.json
@@ -626,11 +626,6 @@
         "type": "address"
       },
       {
-        "internalType": "address",
-        "name": "minter",
-        "type": "address"
-      },
-      {
         "internalType": "uint256",
         "name": "cap_",
         "type": "uint256"

--- a/contracts/AllianceBlockToken.sol
+++ b/contracts/AllianceBlockToken.sol
@@ -14,20 +14,20 @@ contract AllianceBlockToken is ERC20PresetMinterPauserUpgradeable, ERC20Snapshot
     event BatchMint(address indexed sender, uint256 recipientsLength, uint256 totalValue);
 
     constructor() {
-        init("AllianceBlockToken Implementation", "IMPL", address(this), address(this), 1);
+        init("AllianceBlockToken Implementation V1", "IMPL", address(this), 1);
     }
 
-    function init(string memory name, string memory symbol, address admin, address minter, uint256 cap_) public initializer {
+    function init(string memory name, string memory symbol, address admin, uint256 cap_) public initializer {
         __ERC20_init_unchained(name, symbol);
         __ERC20Snapshot_init_unchained();
         __ERC20Permit_init(name);
         __Pausable_init_unchained();
         __AllianceBlockToken_init_unchained(cap_);
         // We don't use __ERC20PresetMinterPauser_init_unchained to avoid giving permisions to _msgSender
+        require(admin != address(0), "NXRA: Admin can't be zero address");
         _setupRole(DEFAULT_ADMIN_ROLE, admin);
         _setupRole(MINTER_ROLE, admin);
         _setupRole(PAUSER_ROLE, admin);
-        _setupRole(MINTER_ROLE, minter);
     }
 
     function __AllianceBlockToken_init_unchained(uint256 cap_) internal onlyInitializing {

--- a/deploy/01 - AllianceBlockToken.ts
+++ b/deploy/01 - AllianceBlockToken.ts
@@ -34,7 +34,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
         execute: {
           init: {
             methodName: "init",
-            args: [TOKEN_NAME, TOKEN_SYMBOL, admin, admin, MAX_TOTAL_SUPPLY],
+            args: [TOKEN_NAME, TOKEN_SYMBOL, admin, MAX_TOTAL_SUPPLY],
           },
         },
       },

--- a/test/AllianceBlockToken.test.ts
+++ b/test/AllianceBlockToken.test.ts
@@ -43,7 +43,7 @@ describe("AllianceBlockToken", function () {
   });
 
   it("can't initizalize 2 times", async () => {
-    await expect(token.init(TOKEN_NAME, TOKEN_SYMBOL, deployer.address, deployer.address, MAX_TOTAL_SUPPLY)).to.be.revertedWith(
+    await expect(token.init(TOKEN_NAME, TOKEN_SYMBOL, deployer.address, MAX_TOTAL_SUPPLY)).to.be.revertedWith(
       "Initializable: contract is already initialized",
     );
   });

--- a/test/ERC20.test.ts
+++ b/test/ERC20.test.ts
@@ -26,7 +26,7 @@ describe("ERC20", () => {
   });
 
   beforeEach(async () => {
-    const populatedTx = await tokenImplementation.populateTransaction.init(name, symbol, initialHolder.address, initialHolder.address, maxTotalSupply);
+    const populatedTx = await tokenImplementation.populateTransaction.init(name, symbol, initialHolder.address, maxTotalSupply);
     testProxy = await TestProxy.deploy(tokenImplementation.address, proxyAdmin.address, populatedTx.data);
     token = await ethers.getContractAt("AllianceBlockToken", testProxy.address) as AllianceBlockToken;
     await token.mint(initialHolder.address, initialSupply);


### PR DESCRIPTION
We advise some basic sanitization to be put in place by ensuring that each address specified is non-zero.

Remove minter init argument as it wont be needed

Close #10